### PR TITLE
fix: 5 CPython parity bugs (set dedup, container repr, finally/else, dict merge, set comparison)

### DIFF
--- a/crates/ouros/src/heap.rs
+++ b/crates/ouros/src/heap.rs
@@ -1702,6 +1702,10 @@ impl PyTrait for HeapData {
             (Self::Time(a), Self::Time(b)) => a.py_cmp(b, heap, interns),
             (Self::Timezone(a), Self::Timezone(b)) => a.py_cmp(b, heap, interns),
             (Self::Fraction(a), Self::Fraction(b)) => a.py_cmp(b, heap, interns),
+            (Self::Set(a), Self::Set(b)) => a.py_cmp(b, heap, interns),
+            (Self::Set(a), Self::FrozenSet(b)) => a.py_cmp_storage(b.storage(), heap, interns),
+            (Self::FrozenSet(a), Self::Set(b)) => a.py_cmp_storage(b.storage(), heap, interns),
+            (Self::FrozenSet(a), Self::FrozenSet(b)) => a.py_cmp(b, heap, interns),
             _ => None,
         }
     }


### PR DESCRIPTION
## Summary

- **Set dedup with custom `__hash__`/`__eq__`**: VM-level dunder dispatch for set add operations — `{V(1), V(2), V(1)}` now correctly gives len=2
- **Container repr calls custom `__repr__`**: `repr([obj])` now shows `[R(custom)]` instead of `[<object at 0x...>]` for lists, tuples, and dicts
- **`finally` runs when `else` branch returns**: Compiler keeps `finally_targets` on stack during else block compilation
- **`dict | dict` merge (PEP 584)**: Added `__or__` and `__ior__` for dict merge and update operators
- **`set <= set` subset comparison**: Implemented `<=`, `<`, `>=`, `>` comparison operators for sets and frozensets

## Test plan

- [x] Bug verification: 15/15 test points pass (was 2/10)
- [x] Full test suite: 1054/1054 with `--features ref-count-panic`
- [x] Parity audit: no regressions
- [x] `make format-rs` and `make lint-rs` clean

Generated by Codex (gpt-5.3-codex), verified by Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dictionary merge support via the `|=` operator.
  * Enabled `repr()` for container types (lists, tuples, dicts) with cycle detection.

* **Bug Fixes**
  * Fixed set and frozenset comparison operations to support subset/superset semantics.
  * Improved hash handling for instances in collections to ensure proper deduplication and key uniqueness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->