### PR TITLE
fix: super().__init__(), super().__new__(cls), and vars() builtin

### DIFF
--- a/crates/ouros/test_cases/builtin__vars.py
+++ b/crates/ouros/test_cases/builtin__vars.py
@@ -1,0 +1,41 @@
+# === vars(obj) returns __dict__ ===
+class WithDict:
+    def __init__(self):
+        self.x = 1
+        self.y = 2
+
+
+obj = WithDict()
+obj_vars = vars(obj)
+assert obj_vars == {'x': 1, 'y': 2}, 'vars(obj) should return object __dict__ mapping'
+
+obj_vars['z'] = 3
+assert obj.z == 3, 'vars(obj) should return the live object __dict__'
+
+
+# === vars(class) returns class namespace mapping ===
+class ClassVars:
+    marker = 7
+
+
+class_vars = vars(ClassVars)
+assert class_vars['marker'] == 7, 'vars(class) should expose class namespace'
+
+
+# === vars(obj) without __dict__ raises TypeError ===
+try:
+    vars(1)
+    assert False, 'vars(1) should raise TypeError because int has no __dict__'
+except TypeError as exc:
+    assert str(exc) == 'vars() argument must have __dict__ attribute', 'vars() missing __dict__ message should match'
+
+
+# === vars() no-arg form: CPython locals dict or sandbox TypeError ===
+try:
+    no_arg_vars = vars()
+except TypeError as exc:
+    assert str(exc) == 'vars() without arguments is not supported in this sandbox', (
+        'vars() no-arg sandbox error message should match'
+    )
+else:
+    assert isinstance(no_arg_vars, dict), 'vars() without args should return locals dict when available'

--- a/crates/ouros/test_cases/super__init.py
+++ b/crates/ouros/test_cases/super__init.py
@@ -1,0 +1,95 @@
+# === super().__init__ reaches object for explicit object subclasses ===
+class ObjectLeaf(object):
+    def __init__(self):
+        super().__init__()
+
+
+leaf = ObjectLeaf()
+assert isinstance(leaf, ObjectLeaf), 'super().__init__() should resolve object.__init__ for object subclasses'
+
+
+# === cooperative super() chain ending at object ===
+class ChainA:
+    def __init__(self):
+        self.chain = ['A']
+        super().__init__()
+
+
+class ChainB(ChainA):
+    def __init__(self):
+        super().__init__()
+        self.chain.append('B')
+
+
+chain = ChainB()
+assert chain.chain == ['A', 'B'], 'cooperative super() chain should execute and terminate at object.__init__'
+
+
+# === diamond super() chain ending at object ===
+class DiamondBase:
+    def __init__(self, log):
+        log.append('base')
+        super().__init__()
+
+
+class DiamondLeft(DiamondBase):
+    def __init__(self, log):
+        log.append('left')
+        super().__init__(log)
+
+
+class DiamondRight(DiamondBase):
+    def __init__(self, log):
+        log.append('right')
+        super().__init__(log)
+
+
+class DiamondBottom(DiamondLeft, DiamondRight):
+    def __init__(self, log):
+        log.append('bottom')
+        super().__init__(log)
+
+
+mro_log = []
+DiamondBottom(mro_log)
+assert mro_log == ['bottom', 'left', 'right', 'base'], 'diamond super() chain should resolve all __init__ calls'
+
+
+# === super().__init__ on builtin container subclasses ===
+class MyList(list):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.tag = 'list-ok'
+
+
+class MyDict(dict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.tag = 'dict-ok'
+
+
+class MySet(set):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.tag = 'set-ok'
+
+
+my_list = MyList([1, 2])
+my_dict = MyDict(a=1)
+my_set = MySet([1, 2])
+
+assert my_list.tag == 'list-ok', 'list subclass super().__init__ should execute without AttributeError'
+assert my_dict.tag == 'dict-ok', 'dict subclass super().__init__ should execute without AttributeError'
+assert my_set.tag == 'set-ok', 'set subclass super().__init__ should execute without AttributeError'
+
+
+# === exception subclasses still resolve super().__init__ ===
+class MyExc(Exception):
+    def __init__(self, message):
+        super().__init__(message)
+
+
+try:
+    raise MyExc('boom')
+except MyExc as exc:
+    assert str(exc) == 'boom', 'exception super().__init__ should preserve message'

--- a/crates/ouros/test_cases/super__new.py
+++ b/crates/ouros/test_cases/super__new.py
@@ -1,0 +1,26 @@
+# === super().__new__(cls, ...) for immutable builtin subclasses ===
+class MyInt(int):
+    def __new__(cls, value):
+        return super().__new__(cls, value)
+
+
+class MyStr(str):
+    def __new__(cls, value):
+        return super().__new__(cls, value)
+
+
+class MyTuple(tuple):
+    def __new__(cls, values):
+        return super().__new__(cls, values)
+
+
+my_int = MyInt(42)
+my_str = MyStr('hello')
+my_tuple = MyTuple((1, 2))
+
+assert my_int == 42, 'super().__new__ for int subclasses should construct a value without TypeError'
+assert isinstance(my_int, int), 'result from int super().__new__ should behave like int'
+assert my_str == 'hello', 'super().__new__ for str subclasses should construct a value without TypeError'
+assert isinstance(my_str, str), 'result from str super().__new__ should behave like str'
+assert my_tuple == (1, 2), 'super().__new__ for tuple subclasses should construct a value without TypeError'
+assert isinstance(my_tuple, tuple), 'result from tuple super().__new__ should behave like tuple'


### PR DESCRIPTION
## Summary

- **super().__init__()** now resolves through the MRO to `object.__init__()` (no-op) and properly delegates to `list/dict/set.__init__()` for builtin subclasses. Previously raised `AttributeError: 'super' object has no attribute '__init__'`, breaking ALL cooperative inheritance chains and ALL builtin subclasses.

- **super().__new__(cls)** for immutable builtin subclasses (`int`, `str`, `tuple`) no longer double-prepends `self`. The explicit `cls` argument is passed through correctly and validated as a proper type object.

- **vars(object)** builtin added — returns `object.__dict__`. The zero-argument form raises `TypeError` in the sandbox (no ambient locals exposure).

- Generalized `builtin_super_method_for_attr()` to synthesize methods for all builtin types during `super()` MRO resolution, replacing the previous exception-only special case.

## Test plan

- [x] `make test-ref-count-panic` — 1060+ tests, 0 failures
- [x] `playground/bug_super_init.py` — list, dict, set, object, A→object chain, diamond, exception all OK
- [x] `playground/bug_super_new.py` — tuple, int, str all OK
- [x] `playground/bug_vars.py` — vars(obj) returns __dict__, no-arg raises TypeError
- [x] `playground/stress_gnarly.py` — 168/168 with full cooperative super() chain restored (was previously using workaround)

Generated by Codex (gpt-5.3-codex) job 7a0defb7, verified by Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `vars()` built-in function to access object attributes and class namespaces.
  * Enhanced `super().__init__()` support for complex inheritance hierarchies, including diamond inheritance patterns.
  * Improved `super().__new__()` support for creating custom immutable builtin subclasses.

* **Bug Fixes**
  * Fixed attribute resolution in `super()` calls to properly traverse the method resolution order.
  * Enhanced validation with more informative error messages for initialization operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->