### PR TITLE
feat: wire exception tracer hooks into VM

### DIFF
--- a/crates/ouros/src/bytecode/vm/mod.rs
+++ b/crates/ouros/src/bytecode/vm/mod.rs
@@ -8912,12 +8912,14 @@ impl<'a, T: ResourceTracker, P: PrintWriter, Tr: VmTracer> VM<'a, T, P, Tr> {
             .expect("exception handler entered without stack exception value");
         self.exception_stack.push(exc_value);
         self.exception_stack_positions.push(stack_pos);
+        self.tracer.on_exception_push(self.exception_stack.len());
     }
 
     /// Pops the current active exception context, if any.
     pub(super) fn pop_exception_context(&mut self) -> Option<Value> {
         let exc = self.exception_stack.pop()?;
         let _ = self.exception_stack_positions.pop();
+        self.tracer.on_exception_pop(self.exception_stack.len());
         Some(exc)
     }
 


### PR DESCRIPTION
## Summary

- Wire the previously dead `on_exception_push`/`on_exception_pop` VmTracer hooks into the VM's `push_exception_context` and `pop_exception_context` methods
- Update all three active tracers: RecordingTracer (event capture), ProfilingTracer (counters), StderrTracer (logging)
- Add 5 unit tests covering basic capture, nested exceptions, profiling counts, event limits, and Clone derive

## Context

The VmTracer trait defined `on_exception_push` and `on_exception_pop` hooks but they had zero call sites in the VM — complete dead code. This wires them up so exception flow is visible to all tracer implementations, which is valuable for LLM code execution observability.

## Test plan

- [x] `make test-ref-count-panic` — all pass
- [x] `cargo test -p ouros --lib -- tests::` — 5 new tests pass
- [x] `cargo run --release -p ouros-cli -- playground/test_exception_tracer.py` — ALL EXCEPTION TRACER TESTS PASSED
- [x] `make format-rs` and `make lint-rs` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added exception event tracking with depth information to the tracer system
  * Exception push/pop counters now included in performance profiling reports
  * Enhanced exception diagnostics in trace output for better error monitoring

<!-- end of auto-generated comment: release notes by coderabbit.ai -->