### PR TITLE
feat: register_external_functions() — set ext funcs without clearing state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ default-members = ["crates/ouros-cli"]
 
 [workspace.package]
 edition = "2024"
-version = "0.0.4"
+version = "0.0.6"
 rust-version = "1.90"
 license = "MIT"
 authors = ["parcadei <227596144+parcadei@users.noreply.github.com>"]

--- a/crates/ouros-js/package.json
+++ b/crates/ouros-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ouros",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "type": "module",
   "description": "Sandboxed Python interpreter for JavaScript/TypeScript",
   "main": "wrapper.js",

--- a/crates/ouros-python/python/ouros/session.py
+++ b/crates/ouros-python/python/ouros/session.py
@@ -126,9 +126,12 @@ class Session:
         """Reset this session to a fresh state."""
         self._manager._native.reset(session_id=self._id, external_functions=external_functions)
 
-    def set_external_functions(self, external_functions: list[str]) -> None:
-        """Register external functions without clearing session state."""
-        self._manager.set_external_functions(external_functions, session_id=self._id)
+    def register_external_functions(self, external_functions: list[str]) -> list[str]:
+        """Register additional external functions without clearing session state.
+
+        Returns names skipped due to collision with existing user variables.
+        """
+        return self._manager.register_external_functions(external_functions, session_id=self._id)
 
     def __repr__(self) -> str:
         return f'Session(id={self._id!r})'
@@ -268,14 +271,17 @@ class SessionManager:
         """Reset a session to a fresh state."""
         self._native.reset(session_id=session_id, external_functions=external_functions)
 
-    def set_external_functions(
+    def register_external_functions(
         self,
         external_functions: list[str],
         *,
         session_id: str | None = None,
-    ) -> None:
-        """Register external functions on an existing session without clearing state."""
-        self._native.set_external_functions(external_functions, session_id=session_id)
+    ) -> list[str]:
+        """Register additional external functions without clearing session state.
+
+        Returns names skipped due to collision with existing user variables.
+        """
+        return self._native.register_external_functions(external_functions, session_id=session_id)
 
     # -- Cross-session pipeline ------------------------------------------------
 

--- a/crates/ouros-python/python/ouros/session.py
+++ b/crates/ouros-python/python/ouros/session.py
@@ -126,6 +126,10 @@ class Session:
         """Reset this session to a fresh state."""
         self._manager._native.reset(session_id=self._id, external_functions=external_functions)
 
+    def set_external_functions(self, external_functions: list[str]) -> None:
+        """Register external functions without clearing session state."""
+        self._manager.set_external_functions(external_functions, session_id=self._id)
+
     def __repr__(self) -> str:
         return f'Session(id={self._id!r})'
 
@@ -263,6 +267,15 @@ class SessionManager:
     def reset(self, *, session_id: str | None = None, external_functions: list[str] | None = None) -> None:
         """Reset a session to a fresh state."""
         self._native.reset(session_id=session_id, external_functions=external_functions)
+
+    def set_external_functions(
+        self,
+        external_functions: list[str],
+        *,
+        session_id: str | None = None,
+    ) -> None:
+        """Register external functions on an existing session without clearing state."""
+        self._native.set_external_functions(external_functions, session_id=session_id)
 
     # -- Cross-session pipeline ------------------------------------------------
 

--- a/crates/ouros-python/src/session_manager.rs
+++ b/crates/ouros-python/src/session_manager.rs
@@ -337,6 +337,21 @@ impl PySessionManager {
         Ok(())
     }
 
+    /// Register external functions on an existing session without clearing state.
+    ///
+    /// Functions already registered are silently skipped. Existing variables
+    /// and history are preserved.
+    #[pyo3(signature = (external_functions, *, session_id=None))]
+    fn set_external_functions(
+        &mut self,
+        external_functions: Vec<String>,
+        session_id: Option<&str>,
+    ) -> PyResult<()> {
+        self.inner
+            .set_external_functions(session_id, external_functions)
+            .map_err(session_err_to_py)
+    }
+
     // -------------------------------------------------------------------------
     // Persistence
     // -------------------------------------------------------------------------

--- a/crates/ouros-python/src/session_manager.rs
+++ b/crates/ouros-python/src/session_manager.rs
@@ -342,11 +342,7 @@ impl PySessionManager {
     /// Functions already registered are silently skipped. Existing variables
     /// and history are preserved.
     #[pyo3(signature = (external_functions, *, session_id=None))]
-    fn set_external_functions(
-        &mut self,
-        external_functions: Vec<String>,
-        session_id: Option<&str>,
-    ) -> PyResult<()> {
+    fn set_external_functions(&mut self, external_functions: Vec<String>, session_id: Option<&str>) -> PyResult<()> {
         self.inner
             .set_external_functions(session_id, external_functions)
             .map_err(session_err_to_py)

--- a/crates/ouros-python/src/session_manager.rs
+++ b/crates/ouros-python/src/session_manager.rs
@@ -337,14 +337,18 @@ impl PySessionManager {
         Ok(())
     }
 
-    /// Register external functions on an existing session without clearing state.
+    /// Register additional external functions without clearing session state.
     ///
-    /// Functions already registered are silently skipped. Existing variables
-    /// and history are preserved.
+    /// Functions already registered are silently skipped. Names that collide
+    /// with existing user variables are skipped and returned.
     #[pyo3(signature = (external_functions, *, session_id=None))]
-    fn set_external_functions(&mut self, external_functions: Vec<String>, session_id: Option<&str>) -> PyResult<()> {
+    fn register_external_functions(
+        &mut self,
+        external_functions: Vec<String>,
+        session_id: Option<&str>,
+    ) -> PyResult<Vec<String>> {
         self.inner
-            .set_external_functions(session_id, external_functions)
+            .register_external_functions(session_id, external_functions)
             .map_err(session_err_to_py)
     }
 
@@ -553,22 +557,44 @@ fn progress_to_dict<'py>(py: Python<'py>, progress: &ReplProgress) -> PyResult<B
             dict.set_item("result", json_to_py(py, &json_val)?)?;
         }
         ReplProgress::FunctionCall {
-            function_name, call_id, ..
+            function_name,
+            call_id,
+            args,
+            kwargs,
         } => {
             dict.set_item("status", "function_call")?;
             dict.set_item("function_name", function_name)?;
             dict.set_item("call_id", call_id)?;
+            let py_args: PyResult<Vec<Py<PyAny>>> = args.iter().map(|a| json_to_py(py, &a.to_json_value())).collect();
+            dict.set_item("args", PyList::new(py, py_args?)?)?;
+            let kw_dict = PyDict::new(py);
+            for (k, v) in kwargs {
+                let key = json_to_py(py, &k.to_json_value())?;
+                let val = json_to_py(py, &v.to_json_value())?;
+                kw_dict.set_item(key, val)?;
+            }
+            dict.set_item("kwargs", kw_dict)?;
         }
         ReplProgress::ProxyCall {
             proxy_id,
             method,
             call_id,
-            ..
+            args,
+            kwargs,
         } => {
             dict.set_item("status", "proxy_call")?;
             dict.set_item("proxy_id", proxy_id)?;
             dict.set_item("method", method)?;
             dict.set_item("call_id", call_id)?;
+            let py_args: PyResult<Vec<Py<PyAny>>> = args.iter().map(|a| json_to_py(py, &a.to_json_value())).collect();
+            dict.set_item("args", PyList::new(py, py_args?)?)?;
+            let kw_dict = PyDict::new(py);
+            for (k, v) in kwargs {
+                let key = json_to_py(py, &k.to_json_value())?;
+                let val = json_to_py(py, &v.to_json_value())?;
+                kw_dict.set_item(key, val)?;
+            }
+            dict.set_item("kwargs", kw_dict)?;
         }
         ReplProgress::ResolveFutures { pending_call_ids, .. } => {
             dict.set_item("status", "resolve_futures")?;

--- a/crates/ouros/src/modules/codecs_mod.rs
+++ b/crates/ouros/src/modules/codecs_mod.rs
@@ -2235,7 +2235,7 @@ fn decode_utf16_ex(data: &[u8], errors: &str, byteorder: i64, final_flag: bool) 
     }
 
     let mut out = String::new();
-    for decoded in char::decode_utf16(units.into_iter()) {
+    for decoded in char::decode_utf16(units) {
         match decoded {
             Ok(ch) => out.push(ch),
             Err(_) => match errors {
@@ -2430,7 +2430,7 @@ fn decode_utf7(data: &[u8], errors: &str, _final_flag: bool) -> RunResult<(Strin
                 units.push(u16::from_be_bytes([decoded_bytes[j], decoded_bytes[j + 1]]));
                 j += 2;
             }
-            for ch in char::decode_utf16(units.into_iter()) {
+            for ch in char::decode_utf16(units) {
                 match ch {
                     Ok(ch) => out.push(ch),
                     Err(_) => match errors {

--- a/crates/ouros/src/modules/itertools.rs
+++ b/crates/ouros/src/modules/itertools.rs
@@ -350,7 +350,7 @@ fn itertools_chain(heap: &mut Heap<impl ResourceTracker>, interns: &Interns, arg
         iter.drop_with_heap(heap);
 
         // items contains owned values - transfer ownership to result
-        result.extend(items.into_iter());
+        result.extend(items);
     }
     // pos is fully consumed above
 

--- a/crates/ouros/src/repl.rs
+++ b/crates/ouros/src/repl.rs
@@ -5,7 +5,7 @@
 
 use std::time::Instant;
 
-use ahash::AHashMap;
+use ahash::{AHashMap, AHashSet};
 use num_bigint::BigInt;
 
 use crate::{
@@ -205,6 +205,8 @@ pub struct ReplSession {
     /// `ResolveFutures` is returned to the host, and stored in
     /// `PendingFuturesState` for incremental resolution.
     future_metadata: AHashMap<u32, PendingFutureInfo>,
+    /// O(1) membership set mirroring `external_functions` for name checks.
+    external_function_set: AHashSet<String>,
 }
 
 impl ReplSession {
@@ -238,6 +240,7 @@ impl ReplSession {
         }
 
         let namespace_size = namespace_values.len();
+        let external_function_set: AHashSet<String> = external_functions.iter().cloned().collect();
 
         Self {
             interner: InternerBuilder::new(""),
@@ -254,6 +257,7 @@ impl ReplSession {
             pending_futures_state: None,
             capabilities: None,
             future_metadata: AHashMap::new(),
+            external_function_set,
         }
     }
 
@@ -270,10 +274,7 @@ impl ReplSession {
 
     /// Returns `true` if `name` is a registered external function.
     fn is_external_function_name(&self, name: &str) -> bool {
-        let Some(&slot) = self.name_map.get(name) else {
-            return false;
-        };
-        matches!(self.namespaces.get(GLOBAL_NS_IDX).get(slot), Value::ExtFunction(_))
+        self.external_function_set.contains(name)
     }
 
     /// Returns the list of registered external function names.
@@ -293,30 +294,41 @@ impl ReplSession {
     /// callable from subsequent `execute()` calls.
     ///
     /// Returns the names that were skipped due to collision with user variables.
-    pub fn register_external_functions(&mut self, new_functions: Vec<String>) -> Vec<String> {
+    pub fn register_external_functions(&mut self, new_functions: Vec<String>) -> Result<Vec<String>, ReplError> {
+        self.ensure_not_waiting_for_resume()?;
         let mut collisions = Vec::new();
         for function_name in new_functions {
-            if self.is_external_function_name(&function_name) {
+            if self.external_function_set.contains(&function_name) {
                 continue;
             }
 
-            // Reject if a user variable already occupies this name.
-            if self.name_map.contains_key(&function_name) {
-                collisions.push(function_name);
-                continue;
+            // Check if a name_map entry exists.
+            if let Some(&existing_slot) = self.name_map.get(&function_name) {
+                let value = self.namespaces.get(GLOBAL_NS_IDX).get(existing_slot);
+                if !matches!(value, Value::Undefined) {
+                    // Live user variable -- reject to preserve state.
+                    collisions.push(function_name);
+                    continue;
+                }
+                // Tombstoned slot (Value::Undefined) -- reuse it.
+                let ext_func_id = ExtFunctionId::new(self.external_functions.len());
+                self.external_functions.push(function_name.clone());
+                self.external_function_set.insert(function_name);
+                *self.namespaces.get_mut(GLOBAL_NS_IDX).get_mut(existing_slot) = Value::ExtFunction(ext_func_id);
+            } else {
+                let ext_func_id = ExtFunctionId::new(self.external_functions.len());
+                self.external_functions.push(function_name.clone());
+                self.external_function_set.insert(function_name.clone());
+
+                let slot = NamespaceId::new(self.namespace_size);
+                self.namespace_size += 1;
+                self.namespaces.grow_global(self.namespace_size);
+                self.name_map.insert(function_name, slot);
+                *self.namespaces.get_mut(GLOBAL_NS_IDX).get_mut(slot) = Value::ExtFunction(ext_func_id);
             }
-
-            let ext_func_id = ExtFunctionId::new(self.external_functions.len());
-            self.external_functions.push(function_name.clone());
-
-            let slot = NamespaceId::new(self.namespace_size);
-            self.namespace_size += 1;
-            self.namespaces.grow_global(self.namespace_size);
-            self.name_map.insert(function_name, slot);
-            *self.namespaces.get_mut(GLOBAL_NS_IDX).get_mut(slot) = Value::ExtFunction(ext_func_id);
         }
         self.external_function_count = self.external_functions.len();
-        collisions
+        Ok(collisions)
     }
 
     /// Returns the current capability set, if any.
@@ -361,6 +373,7 @@ impl ReplSession {
             pending_futures_state: None,
             capabilities: self.capabilities.clone(),
             future_metadata: AHashMap::new(),
+            external_function_set: self.external_function_set.clone(),
         }
     }
 
@@ -434,6 +447,7 @@ impl ReplSession {
         );
 
         let name_map: AHashMap<String, NamespaceId> = snapshot.name_map.into_iter().collect();
+        let external_function_set: AHashSet<String> = snapshot.external_functions.iter().cloned().collect();
 
         Ok(Self {
             interner,
@@ -450,6 +464,7 @@ impl ReplSession {
             pending_futures_state: None,
             capabilities: None,
             future_metadata: AHashMap::new(),
+            external_function_set,
         })
     }
 

--- a/crates/ouros/src/repl.rs
+++ b/crates/ouros/src/repl.rs
@@ -181,8 +181,6 @@ pub struct ReplSession {
     name_map: AHashMap<String, NamespaceId>,
     /// Current size of the global namespace.
     namespace_size: usize,
-    /// Number of external function slots at the start of the namespace.
-    external_function_count: usize,
     /// Script name used in parse/runtime error reporting.
     script_name: String,
     /// VM snapshot waiting to be resumed after an interactive yield.
@@ -250,7 +248,6 @@ impl ReplSession {
             namespaces: Namespaces::new(namespace_values),
             name_map,
             namespace_size,
-            external_function_count: external_function_ids.len(),
             script_name: script_name.to_string(),
             pending_snapshot: None,
             pending_resume_state: None,
@@ -327,7 +324,6 @@ impl ReplSession {
                 *self.namespaces.get_mut(GLOBAL_NS_IDX).get_mut(slot) = Value::ExtFunction(ext_func_id);
             }
         }
-        self.external_function_count = self.external_functions.len();
         Ok(collisions)
     }
 
@@ -366,7 +362,6 @@ impl ReplSession {
             namespaces: self.namespaces.deep_clone(),
             name_map: self.name_map.clone(),
             namespace_size: self.namespace_size,
-            external_function_count: self.external_function_count,
             script_name: self.script_name.clone(),
             pending_snapshot: None,
             pending_resume_state: None,
@@ -410,7 +405,7 @@ impl ReplSession {
             namespaces_bytes,
             name_map: self.name_map.iter().map(|(k, v)| (k.clone(), *v)).collect(),
             namespace_size: self.namespace_size,
-            external_function_count: self.external_function_count,
+            external_function_count: self.external_functions.len(),
             script_name: self.script_name.clone(),
         };
 
@@ -457,7 +452,6 @@ impl ReplSession {
             namespaces,
             name_map,
             namespace_size: snapshot.namespace_size,
-            external_function_count: snapshot.external_function_count,
             script_name: snapshot.script_name,
             pending_snapshot: None,
             pending_resume_state: None,

--- a/crates/ouros/src/repl.rs
+++ b/crates/ouros/src/repl.rs
@@ -268,6 +268,50 @@ impl ReplSession {
         self.capabilities = capabilities;
     }
 
+    /// Returns `true` if `name` is a registered external function.
+    fn is_external_function_name(&self, name: &str) -> bool {
+        self.external_functions.iter().any(|f| f == name)
+    }
+
+    /// Returns the list of registered external function names.
+    #[must_use]
+    pub fn external_function_names(&self) -> &[String] {
+        &self.external_functions
+    }
+
+    /// Registers additional external functions on an existing session without
+    /// clearing state.
+    ///
+    /// Functions that are already registered (by name) are silently skipped.
+    /// New functions are added at the end of the namespace and are immediately
+    /// callable from subsequent `execute()` calls.
+    pub fn register_external_functions(&mut self, new_functions: Vec<String>) {
+        for function_name in new_functions {
+            if self.is_external_function_name(&function_name) {
+                continue;
+            }
+
+            let ext_func_id = ExtFunctionId::new(self.external_functions.len());
+            self.external_functions.push(function_name.clone());
+
+            // If a user variable already occupies this name, replace it.
+            if let Some(&existing_slot) = self.name_map.get(&function_name) {
+                let old = std::mem::replace(
+                    self.namespaces.get_mut(GLOBAL_NS_IDX).get_mut(existing_slot),
+                    Value::ExtFunction(ext_func_id),
+                );
+                old.drop_with_heap(&mut self.heap);
+            } else {
+                let slot = NamespaceId::new(self.namespace_size);
+                self.namespace_size += 1;
+                self.namespaces.grow_global(self.namespace_size);
+                self.name_map.insert(function_name, slot);
+                *self.namespaces.get_mut(GLOBAL_NS_IDX).get_mut(slot) = Value::ExtFunction(ext_func_id);
+            }
+        }
+        self.external_function_count = self.external_functions.len();
+    }
+
     /// Returns the current capability set, if any.
     #[must_use]
     pub fn capabilities(&self) -> Option<&CapabilitySet> {
@@ -671,7 +715,7 @@ impl ReplSession {
         let mut vars = Vec::new();
 
         for (name, &slot) in &self.name_map {
-            if slot.index() < self.external_function_count {
+            if self.is_external_function_name(name) {
                 continue;
             }
             let value = global.get(slot);
@@ -691,7 +735,7 @@ impl ReplSession {
     #[must_use]
     pub fn get_variable(&self, name: &str) -> Option<Object> {
         let &slot = self.name_map.get(name)?;
-        if slot.index() < self.external_function_count {
+        if self.is_external_function_name(name) {
             return None;
         }
 
@@ -719,7 +763,7 @@ impl ReplSession {
 
         // First check if the variable exists
         let &slot = self.name_map.get(name)?;
-        if slot.index() < self.external_function_count {
+        if self.is_external_function_name(name) {
             return None;
         }
 
@@ -791,7 +835,7 @@ impl ReplSession {
         let new_value = value.to_value(&mut self.heap, &interns)?;
 
         if let Some(&existing_slot) = self.name_map.get(name) {
-            if existing_slot.index() < self.external_function_count {
+            if self.is_external_function_name(name) {
                 new_value.drop_with_heap(&mut self.heap);
                 return Err(InvalidInputError::invalid_type("cannot overwrite external function"));
             }
@@ -834,7 +878,7 @@ impl ReplSession {
             return Ok(false);
         };
 
-        if slot.index() < self.external_function_count {
+        if self.is_external_function_name(name) {
             return Err(InvalidInputError::invalid_type("cannot delete external function"));
         }
 

--- a/crates/ouros/src/repl.rs
+++ b/crates/ouros/src/repl.rs
@@ -270,7 +270,10 @@ impl ReplSession {
 
     /// Returns `true` if `name` is a registered external function.
     fn is_external_function_name(&self, name: &str) -> bool {
-        self.external_functions.iter().any(|f| f == name)
+        let Some(&slot) = self.name_map.get(name) else {
+            return false;
+        };
+        matches!(self.namespaces.get(GLOBAL_NS_IDX).get(slot), Value::ExtFunction(_))
     }
 
     /// Returns the list of registered external function names.
@@ -282,34 +285,38 @@ impl ReplSession {
     /// Registers additional external functions on an existing session without
     /// clearing state.
     ///
-    /// Functions that are already registered (by name) are silently skipped.
+    /// Functions that are already registered as external functions are silently
+    /// skipped. Names that collide with existing user variables are also skipped
+    /// to avoid destroying session state.
+    ///
     /// New functions are added at the end of the namespace and are immediately
     /// callable from subsequent `execute()` calls.
-    pub fn register_external_functions(&mut self, new_functions: Vec<String>) {
+    ///
+    /// Returns the names that were skipped due to collision with user variables.
+    pub fn register_external_functions(&mut self, new_functions: Vec<String>) -> Vec<String> {
+        let mut collisions = Vec::new();
         for function_name in new_functions {
             if self.is_external_function_name(&function_name) {
+                continue;
+            }
+
+            // Reject if a user variable already occupies this name.
+            if self.name_map.contains_key(&function_name) {
+                collisions.push(function_name);
                 continue;
             }
 
             let ext_func_id = ExtFunctionId::new(self.external_functions.len());
             self.external_functions.push(function_name.clone());
 
-            // If a user variable already occupies this name, replace it.
-            if let Some(&existing_slot) = self.name_map.get(&function_name) {
-                let old = std::mem::replace(
-                    self.namespaces.get_mut(GLOBAL_NS_IDX).get_mut(existing_slot),
-                    Value::ExtFunction(ext_func_id),
-                );
-                old.drop_with_heap(&mut self.heap);
-            } else {
-                let slot = NamespaceId::new(self.namespace_size);
-                self.namespace_size += 1;
-                self.namespaces.grow_global(self.namespace_size);
-                self.name_map.insert(function_name, slot);
-                *self.namespaces.get_mut(GLOBAL_NS_IDX).get_mut(slot) = Value::ExtFunction(ext_func_id);
-            }
+            let slot = NamespaceId::new(self.namespace_size);
+            self.namespace_size += 1;
+            self.namespaces.grow_global(self.namespace_size);
+            self.name_map.insert(function_name, slot);
+            *self.namespaces.get_mut(GLOBAL_NS_IDX).get_mut(slot) = Value::ExtFunction(ext_func_id);
         }
         self.external_function_count = self.external_functions.len();
+        collisions
     }
 
     /// Returns the current capability set, if any.

--- a/crates/ouros/src/session_manager.rs
+++ b/crates/ouros/src/session_manager.rs
@@ -964,7 +964,8 @@ impl SessionManager {
     ///
     /// # Errors
     ///
-    /// Returns `SessionError::NotFound` if the session does not exist.
+    /// Returns `SessionError::NotFound` if the session does not exist, or
+    /// `SessionError::InvalidState` if the session has a pending external call.
     pub fn register_external_functions(
         &mut self,
         session_id: Option<&str>,

--- a/crates/ouros/src/session_manager.rs
+++ b/crates/ouros/src/session_manager.rs
@@ -972,7 +972,6 @@ impl SessionManager {
         entry.external_functions = entry.session.external_function_names().to_vec();
         Ok(())
     }
-
 }
 
 // =============================================================================

--- a/crates/ouros/src/session_manager.rs
+++ b/crates/ouros/src/session_manager.rs
@@ -972,7 +972,7 @@ impl SessionManager {
     ) -> Result<Vec<String>, SessionError> {
         let sid = resolve_session_id(session_id);
         let entry = self.get_session_mut(sid)?;
-        let collisions = entry.session.register_external_functions(external_functions);
+        let collisions = entry.session.register_external_functions(external_functions)?;
         entry.external_functions = entry.session.external_function_names().to_vec();
         Ok(collisions)
     }

--- a/crates/ouros/src/session_manager.rs
+++ b/crates/ouros/src/session_manager.rs
@@ -951,6 +951,28 @@ impl SessionManager {
         entry.history.clear();
         Ok(())
     }
+
+    /// Registers external functions on an existing session without clearing state.
+    ///
+    /// Functions already registered (by name) are silently skipped. New functions
+    /// are appended and become immediately callable. Existing variables and
+    /// execution history are preserved.
+    ///
+    /// # Errors
+    ///
+    /// Returns `SessionError::NotFound` if the session does not exist.
+    pub fn set_external_functions(
+        &mut self,
+        session_id: Option<&str>,
+        external_functions: Vec<String>,
+    ) -> Result<(), SessionError> {
+        let sid = resolve_session_id(session_id);
+        let entry = self.get_session_mut(sid)?;
+        entry.session.register_external_functions(external_functions);
+        entry.external_functions = entry.session.external_function_names().to_vec();
+        Ok(())
+    }
+
 }
 
 // =============================================================================

--- a/crates/ouros/src/session_manager.rs
+++ b/crates/ouros/src/session_manager.rs
@@ -952,25 +952,29 @@ impl SessionManager {
         Ok(())
     }
 
-    /// Registers external functions on an existing session without clearing state.
+    /// Registers additional external functions on an existing session without
+    /// clearing state.
     ///
-    /// Functions already registered (by name) are silently skipped. New functions
-    /// are appended and become immediately callable. Existing variables and
-    /// execution history are preserved.
+    /// Functions already registered are silently skipped. Names that collide
+    /// with existing user variables are skipped (returned in the result vec).
+    /// New functions are appended and become immediately callable. Existing
+    /// variables and execution history are preserved.
+    ///
+    /// Returns the names that were skipped due to collision with user variables.
     ///
     /// # Errors
     ///
     /// Returns `SessionError::NotFound` if the session does not exist.
-    pub fn set_external_functions(
+    pub fn register_external_functions(
         &mut self,
         session_id: Option<&str>,
         external_functions: Vec<String>,
-    ) -> Result<(), SessionError> {
+    ) -> Result<Vec<String>, SessionError> {
         let sid = resolve_session_id(session_id);
         let entry = self.get_session_mut(sid)?;
-        entry.session.register_external_functions(external_functions);
+        let collisions = entry.session.register_external_functions(external_functions);
         entry.external_functions = entry.session.external_function_names().to_vec();
-        Ok(())
+        Ok(collisions)
     }
 }
 

--- a/crates/ouros/src/session_manager.rs
+++ b/crates/ouros/src/session_manager.rs
@@ -972,6 +972,13 @@ impl SessionManager {
     ) -> Result<Vec<String>, SessionError> {
         let sid = resolve_session_id(session_id);
         let entry = self.get_session_mut(sid)?;
+
+        if entry.pending_call_id.is_some() {
+            return Err(SessionError::InvalidState(
+                "cannot register external functions while a call is pending".to_owned(),
+            ));
+        }
+
         let collisions = entry.session.register_external_functions(external_functions)?;
         entry.external_functions = entry.session.external_function_names().to_vec();
         Ok(collisions)

--- a/crates/ouros/src/types/weakref.rs
+++ b/crates/ouros/src/types/weakref.rs
@@ -219,7 +219,7 @@ impl PyTrait for WeakRef {
         let self_ptr = std::ptr::from_ref::<Self>(self) as usize;
         if let Some(target) = &self.direct_target {
             let target_type = target.py_type(heap);
-            return write!(f, "<weakref at 0x{self_ptr:x}; to '{target_type}' at 0x0>",);
+            return write!(f, "<weakref at 0x{self_ptr:x}; to '{target_type}' at 0x0>");
         }
         if let Some(target_id) = self.target {
             let target_type = heap

--- a/crates/ouros/src/value.rs
+++ b/crates/ouros/src/value.rs
@@ -2616,14 +2616,12 @@ impl Value {
         interns: &Interns,
     ) -> RunResult<AttrCallResult> {
         match self {
-            Self::Int(_) | Self::Bool(_) => {
-                if interns.get_str(name_id) == "bit_length" {
-                    let bound_id = heap.allocate(HeapData::BoundMethod(crate::types::BoundMethod::new(
-                        Self::Builtin(Builtins::Function(BuiltinsFunctions::IntBitLength)),
-                        self.copy_for_extend(),
-                    )))?;
-                    return Ok(AttrCallResult::Value(Self::Ref(bound_id)));
-                }
+            Self::Int(_) | Self::Bool(_) if interns.get_str(name_id) == "bit_length" => {
+                let bound_id = heap.allocate(HeapData::BoundMethod(crate::types::BoundMethod::new(
+                    Self::Builtin(Builtins::Function(BuiltinsFunctions::IntBitLength)),
+                    self.copy_for_extend(),
+                )))?;
+                return Ok(AttrCallResult::Value(Self::Ref(bound_id)));
             }
             Self::Ref(heap_id) => {
                 if interns.get_str(name_id) == "bit_length" && matches!(heap.get(*heap_id), HeapData::LongInt(_)) {
@@ -3078,14 +3076,13 @@ impl Value {
                 let exception_type_value = Self::Builtin(Builtins::Type(Type::Exception(*exc_type)));
                 return exception_type_value.py_getattr(name_id, heap, interns);
             }
-            Self::ModuleFunction(module_function) => {
+            Self::ModuleFunction(module_function)
                 if matches!(module_function, ModuleFunctions::Itertools(ItertoolsFunctions::Chain))
-                    && interns.get_str(name_id) == "from_iterable"
-                {
-                    return Ok(AttrCallResult::Value(Self::ModuleFunction(ModuleFunctions::Itertools(
-                        ItertoolsFunctions::ChainFromIterable,
-                    ))));
-                }
+                    && interns.get_str(name_id) == "from_iterable" =>
+            {
+                return Ok(AttrCallResult::Value(Self::ModuleFunction(ModuleFunctions::Itertools(
+                    ItertoolsFunctions::ChainFromIterable,
+                ))));
             }
             Self::DefFunction(f_id) => {
                 let func = interns.get_function(*f_id);


### PR DESCRIPTION
## Summary

- Adds `register_external_functions()` to `ReplSession` — appends new external functions to an existing session **without clearing state** (variables, heap, history all preserved)
- Adds `set_external_functions()` to `SessionManager`, Python bindings, and Python `Session`/`SessionManager` wrappers
- Replaces contiguous-slot assumption (`slot.index() < external_function_count`) with name-based `is_external_function_name()` check across 5 sites, needed because dynamically added functions occupy non-contiguous namespace slots

## Motivation

Previously the only way to register external functions was via `reset()`, which wipes all variables. This made save/load workflows fragile — callers had to snapshot variables via `repr()` and restore them after reset, losing any values that don't round-trip through repr.

## Test plan

- [x] `cargo test -p ouros` — 38 unit + 146 integration + 6 doc tests pass
- [x] Python: state preserved after `set_external_functions()` 
- [x] Python: newly registered functions are callable (pause execution correctly)
- [x] Python: save → load → `set_external_functions()` round-trip preserves all state

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core REPL session state management and Python bindings; incorrect slot/name handling could break variable visibility or allow unintended overwrites of user state across executions and persistence.
> 
> **Overview**
> Adds `register_external_functions()` end-to-end (Rust `ReplSession`/`SessionManager`, PyO3, and Python wrappers) to append new external function bindings **without resetting** variables/heap/history, returning any names skipped due to collisions.
> 
> Refactors external-function protection checks from a contiguous-slot assumption to a name-based set (`external_function_set`/`is_external_function_name`) so dynamically added functions can be safely excluded from `list/get/set/delete` variable operations, including after save/load.
> 
> Extends Python progress dicts for `function_call`/`proxy_call` to include `args` and `kwargs`, and bumps package versions to `0.0.6` with a few small iterator/formatting cleanups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3625abdc3521e8aa87e16c74b5036765fcdda3f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Register additional external functions per session without resetting state; returns any colliding names.
  * Progress entries for function/proxy calls now include args and kwargs for richer UI/inspection.

* **Bug Fixes**
  * External functions are protected from being overwritten or deleted by normal variable operations.

* **Other**
  * Minor serialization, decoding, and representation tweaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->