### PR TITLE
fix: widen CodeLoc line/column from u16 to u32

### DIFF
--- a/crates/ouros-python/src/exceptions.rs
+++ b/crates/ouros-python/src/exceptions.rs
@@ -301,16 +301,16 @@ pub struct PyFrame {
     pub filename: String,
     /// Line number (1-based).
     #[pyo3(get)]
-    pub line: u16,
+    pub line: u32,
     /// Column number (1-based).
     #[pyo3(get)]
-    pub column: u16,
+    pub column: u32,
     /// End line number (1-based).
     #[pyo3(get)]
-    pub end_line: u16,
+    pub end_line: u32,
     /// End column number (1-based).
     #[pyo3(get)]
-    pub end_column: u16,
+    pub end_column: u32,
     /// The name of the function, or None for module-level code.
     #[pyo3(get)]
     pub function_name: Option<String>,

--- a/crates/ouros/src/bytecode/code.rs
+++ b/crates/ouros/src/bytecode/code.rs
@@ -155,7 +155,7 @@ impl Code {
     ///
     /// Useful for locating the first executable line inside a compound statement body.
     #[must_use]
-    pub(crate) fn first_location_after_line(&self, line: u16) -> Option<CodeRange> {
+    pub(crate) fn first_location_after_line(&self, line: u32) -> Option<CodeRange> {
         let mut best: Option<CodeRange> = None;
         for entry in &self.location_table {
             let range = entry.range();

--- a/crates/ouros/src/bytecode/vm/call.rs
+++ b/crates/ouros/src/bytecode/vm/call.rs
@@ -3208,8 +3208,8 @@ impl<T: ResourceTracker, P: PrintWriter, Tr: VmTracer> VM<'_, T, P, Tr> {
     }
 
     /// Loads a single source line for warning formatting and strips leading whitespace.
-    fn warning_source_line(filename: &str, line_number: u16) -> Option<String> {
-        let line_index = usize::from(line_number.saturating_sub(1));
+    fn warning_source_line(filename: &str, line_number: u32) -> Option<String> {
+        let line_index = line_number.saturating_sub(1) as usize;
         fs::read_to_string(filename)
             .ok()?
             .lines()

--- a/crates/ouros/src/bytecode/vm/mod.rs
+++ b/crates/ouros/src/bytecode/vm/mod.rs
@@ -9596,7 +9596,7 @@ impl<'a, T: ResourceTracker, P: PrintWriter, Tr: VmTracer> VM<'a, T, P, Tr> {
     /// 3. Move namespace values back to the generator
     /// 4. Mark the generator as Suspended and store the suspension line number
     /// 5. Push the yielded value onto the stack for the caller
-    fn suspend_generator_frame(&mut self, generator_id: HeapId, yielded_value: Value, suspended_lineno: u16) {
+    fn suspend_generator_frame(&mut self, generator_id: HeapId, yielded_value: Value, suspended_lineno: u32) {
         // Pop the generator frame
         let frame = self.frames.pop().expect("no generator frame to suspend");
         let saved_ip = frame.ip;

--- a/crates/ouros/src/bytecode/vm/mod.rs
+++ b/crates/ouros/src/bytecode/vm/mod.rs
@@ -8702,10 +8702,7 @@ impl<'a, T: ResourceTracker, P: PrintWriter, Tr: VmTracer> VM<'a, T, P, Tr> {
     /// This releases the extra reference held for the receiver when the
     /// `__getattribute__` frame completes normally.
     fn drop_pending_getattr_for_frame(&mut self, frame_depth: usize) {
-        if let Some(pending) = self.pending_getattr_fallback.last()
-            && pending.frame_depth == frame_depth
-        {
-            let pending = self.pending_getattr_fallback.pop().expect("checked pending entry");
+        if let Some(pending) = self.pending_getattr_fallback.pop_if(|p| p.frame_depth == frame_depth) {
             Value::Ref(pending.obj_id).drop_with_heap(self.heap);
         }
     }
@@ -8784,10 +8781,7 @@ impl<'a, T: ResourceTracker, P: PrintWriter, Tr: VmTracer> VM<'a, T, P, Tr> {
     /// This releases held operand references when a dunder frame exits via
     /// exception unwinding before the protocol completes.
     fn drop_pending_binary_dunder_for_frame(&mut self, frame_depth: usize) {
-        if let Some(pending) = self.pending_binary_dunder.last()
-            && pending.frame_depth == frame_depth
-        {
-            let pending = self.pending_binary_dunder.pop().expect("checked pending binary dunder");
+        if let Some(pending) = self.pending_binary_dunder.pop_if(|p| p.frame_depth == frame_depth) {
             pending.lhs.drop_with_heap(self.heap);
             pending.rhs.drop_with_heap(self.heap);
         }
@@ -8806,13 +8800,7 @@ impl<'a, T: ResourceTracker, P: PrintWriter, Tr: VmTracer> VM<'a, T, P, Tr> {
     /// This releases held operand references when a compare dunder frame exits via
     /// exception unwinding before the protocol completes.
     fn drop_pending_compare_dunder_for_frame(&mut self, frame_depth: usize) {
-        if let Some(pending) = self.pending_compare_dunder.last()
-            && pending.frame_depth == frame_depth
-        {
-            let pending = self
-                .pending_compare_dunder
-                .pop()
-                .expect("checked pending compare dunder");
+        if let Some(pending) = self.pending_compare_dunder.pop_if(|p| p.frame_depth == frame_depth) {
             pending.lhs.drop_with_heap(self.heap);
             pending.rhs.drop_with_heap(self.heap);
         }
@@ -8837,10 +8825,7 @@ impl<'a, T: ResourceTracker, P: PrintWriter, Tr: VmTracer> VM<'a, T, P, Tr> {
     }
 
     fn drop_pending_print_call_for_frame(&mut self, frame_depth: usize) {
-        if let Some(pending) = self.pending_print_call.last()
-            && pending.frame_depth == frame_depth
-        {
-            let pending = self.pending_print_call.pop().expect("checked pending print call");
+        if let Some(pending) = self.pending_print_call.pop_if(|p| p.frame_depth == frame_depth) {
             self.drop_pending_print_call_values(pending);
         }
     }

--- a/crates/ouros/src/exception_public.rs
+++ b/crates/ouros/src/exception_public.rs
@@ -371,12 +371,17 @@ impl CodeLoc {
     /// Lines and columns numbers are 1-indexed for display, hence `+1`
     ///
     /// # Panics
-    /// Panics if the line or column number overflows `u16`.
+    /// Panics if the line or column number + 1 does not fit in `u32`.
     #[must_use]
     pub fn new(line: usize, column: usize) -> Self {
-        Self {
-            line: u32::try_from(line).expect("Line number overflow") + 1,
-            column: u32::try_from(column).expect("Column number overflow") + 1,
-        }
+        let line = line
+            .checked_add(1)
+            .and_then(|v| u32::try_from(v).ok())
+            .expect("Line number overflow");
+        let column = column
+            .checked_add(1)
+            .and_then(|v| u32::try_from(v).ok())
+            .expect("Column number overflow");
+        Self { line, column }
     }
 }

--- a/crates/ouros/src/exception_public.rs
+++ b/crates/ouros/src/exception_public.rs
@@ -354,9 +354,9 @@ impl StackFrame {
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct CodeLoc {
     /// Line number (1-based).
-    pub line: u16,
+    pub line: u32,
     /// Column number (1-based).
-    pub column: u16,
+    pub column: u32,
 }
 
 impl Default for CodeLoc {
@@ -375,8 +375,8 @@ impl CodeLoc {
     #[must_use]
     pub fn new(line: usize, column: usize) -> Self {
         Self {
-            line: u16::try_from(line).expect("Line number overflow") + 1,
-            column: u16::try_from(column).expect("Column number overflow") + 1,
+            line: u32::try_from(line).expect("Line number overflow") + 1,
+            column: u32::try_from(column).expect("Column number overflow") + 1,
         }
     }
 }

--- a/crates/ouros/src/types/generator.rs
+++ b/crates/ouros/src/types/generator.rs
@@ -64,7 +64,7 @@ pub(crate) struct Generator {
     /// This tracks `gi_frame.f_lineno` while the generator is suspended.
     /// `None` means no suspension line has been recorded yet.
     #[serde(default)]
-    pub saved_lineno: Option<u16>,
+    pub saved_lineno: Option<u32>,
 }
 
 impl Generator {

--- a/crates/ouros/src/value.rs
+++ b/crates/ouros/src/value.rs
@@ -3250,7 +3250,7 @@ impl Value {
     /// The proxy exposes only the fields used by parity checks: `f_code` and `f_lineno`.
     fn new_generator_frame_proxy(
         func_id: FunctionId,
-        lineno: u16,
+        lineno: u32,
         heap: &mut Heap<impl ResourceTracker>,
         interns: &Interns,
     ) -> RunResult<Self> {

--- a/crates/ouros/tests/session_manager_tests.rs
+++ b/crates/ouros/tests/session_manager_tests.rs
@@ -120,6 +120,21 @@ fn set_variable_via_expression() {
     assert_eq!(val.json_value, serde_json::json!([1, 2, 3]));
 }
 
+/// Regression: setting a variable to a very long single-line string literal
+/// used to panic because the parser's `CodeLoc` stored column as `u16`,
+/// which overflows at 65 536 characters.
+#[test]
+fn set_variable_large_string_does_not_overflow_column() {
+    let mut mgr = SessionManager::new("test.py");
+    // 100k chars — well past the old u16::MAX (65 535) limit
+    let big = "x".repeat(100_000);
+    let expr = format!("'{big}'");
+    mgr.set_variable(None, "context", &expr).unwrap();
+
+    let val = mgr.get_variable(None, "context").unwrap();
+    assert_eq!(val.json_value, serde_json::json!(big));
+}
+
 #[test]
 fn delete_variable() {
     let mut mgr = SessionManager::new("test.py");


### PR DESCRIPTION
## Summary

- `CodeLoc` stored `line` and `column` as `u16` (max 65,535). Parsing a single-line string >65K chars — e.g. `SessionManager::set_variable("context", repr(large_string))` — panicked with "Column number overflow" in `CodeLoc::new`.
- Widened both fields to `u32` across all 8 affected files: `CodeLoc`, `Generator.saved_lineno`, `suspend_generator_frame`, `first_location_after_line`, `warning_source_line`, `PyFrame`, and `new_generator_frame_proxy`.
- Added regression test `set_variable_large_string_does_not_overflow_column` that sets a 100K-char string literal through `SessionManager::set_variable`.

## Test plan

- [x] `cargo build --workspace` — zero errors, zero warnings
- [x] `cargo test --workspace` — all tests pass
- [x] New regression test passes: `cargo test -p ouros --test session_manager_tests set_variable_large_string`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes core source-location types across the VM, generator state serialization, and Python bindings; could impact compatibility/serde formats but logic changes are minimal.
> 
> **Overview**
> Prevents panics on very long single-line inputs by widening source location line/column storage from `u16` to `u32` across the interpreter (`CodeLoc`, traceback `Frame`/`PyFrame`, VM warning formatting, bytecode location helpers, and generator suspension line tracking).
> 
> Adds a regression test in `session_manager_tests` that sets a 100k-character string literal via `SessionManager::set_variable` to ensure large columns no longer overflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e129b50780f416d7a4c1a2b763cfa6de0b45a4ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Line/column tracking now supports much larger values so exception frames, generator suspension info, and warning source-lines report correct positions in very large files.
* **Tests**
  * Added a regression test verifying very large single-line string variables are stored and retrieved without overflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->